### PR TITLE
Resolve issue with PSN names containing a dash not pulling levels properly

### DIFF
--- a/ovrstat/player_stats.go
+++ b/ovrstat/player_stats.go
@@ -99,7 +99,14 @@ func playerStats(profilePath string, platform string) (*PlayerStats, error) {
 		IsPublic    bool   `json:"isPublic"`
 	}
 	var platforms []Platform
-	apires, err := http.Get(apiURL + strings.Replace(profilePath[strings.LastIndex(profilePath, "/")+1:], "-", "%23", -1))
+
+	apiPath := profilePath[strings.LastIndex(profilePath, "/")+1:]
+
+	if platform != PlatformPSN {
+		apiPath = strings.Replace(apiPath, "-", "%23", -1)
+	}
+
+	apires, err := http.Get(apiURL + apiPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to perform platform API request")
 	}


### PR DESCRIPTION
It was brought to my attention that PSN names can contain `-` which breaks the API request, since the request simply re-encodes it all to the HTML equivalent of `#` (`%23`)

So far, it seems like PSN is the only platform without discriminators, so this patch should work decently, but definitely needs to be fixed in the future. Perhaps enforcing encoded urls instead of using `-` would work?