### PR TITLE
Slightly rewrite platform request to use exact names if multiple results

### DIFF
--- a/ovrstat/models.go
+++ b/ovrstat/models.go
@@ -2,19 +2,19 @@ package ovrstat
 
 // PlayerStats holds all stats on a specified Overwatch player
 type PlayerStats struct {
-	Icon             string            `json:"icon"`
-	Name             string            `json:"name"`
-	Level            int               `json:"level"`
-	LevelIcon        string            `json:"levelIcon"`
-	Endorsement      int               `json:"endorsement"`
-	EndorsementIcon  string            `json:"endorsementIcon"`
-	Prestige         int               `json:"prestige"`
-	PrestigeIcon     string            `json:"prestigeIcon"`
-	Ratings          []Rating 		   `json:"ratings"`
-	GamesWon         int               `json:"gamesWon"`
-	QuickPlayStats   statsCollection   `json:"quickPlayStats"`
-	CompetitiveStats statsCollection   `json:"competitiveStats"`
-	Private          bool              `json:"private"`
+	Icon             string          `json:"icon"`
+	Name             string          `json:"name"`
+	Level            int             `json:"level"`
+	LevelIcon        string          `json:"levelIcon"`
+	Endorsement      int             `json:"endorsement"`
+	EndorsementIcon  string          `json:"endorsementIcon"`
+	Prestige         int             `json:"prestige"`
+	PrestigeIcon     string          `json:"prestigeIcon"`
+	Ratings          []Rating        `json:"ratings"`
+	GamesWon         int             `json:"gamesWon"`
+	QuickPlayStats   statsCollection `json:"quickPlayStats"`
+	CompetitiveStats statsCollection `json:"competitiveStats"`
+	Private          bool            `json:"private"`
 }
 
 type Rating struct {
@@ -52,4 +52,15 @@ type careerStats struct {
 	Game          map[string]interface{} `json:"game"`
 	MatchAwards   map[string]interface{} `json:"matchAwards"`
 	Miscellaneous map[string]interface{} `json:"miscellaneous"`
+}
+
+// Platform represents a response from the search-by-name api request
+type Platform struct {
+	Platform    string `json:"platform"`
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	URLName     string `json:"urlName"`
+	PlayerLevel int    `json:"playerLevel"`
+	Portrait    string `json:"portrait"`
+	IsPublic    bool   `json:"isPublic"`
 }


### PR DESCRIPTION
This will resolve the issues mentioned in #53 by only checking for an exact match, and falling back if there is no exact match. This should be a good middle ground to avoid any bugs/breaking changes while still matching names properly.