### PR TITLE
Potential patch for Nintendo Switch

### DIFF
--- a/ovrstat/player_stats.go
+++ b/ovrstat/player_stats.go
@@ -91,9 +91,12 @@ func playerStats(profilePath string, platform string) (*PlayerStats, error) {
 	// Perform api request
 	var platforms []Platform
 
-	apiPath := profilePath[strings.LastIndex(profilePath, "/")+1:]
+	tagPath := profilePath[strings.LastIndex(profilePath, "/")+1:]
+	apiPath := tagPath
 
-	if platform != PlatformPSN {
+	if platform == PlatformNS {
+		apiPath = apiPath[0:strings.Index(apiPath, "-")] + "/"
+	} else if platform != PlatformPSN {
 		apiPath = strings.Replace(apiPath, "-", "%23", -1)
 	}
 
@@ -108,7 +111,7 @@ func playerStats(profilePath string, platform string) (*PlayerStats, error) {
 		return nil, errors.Wrap(err, "Failed to decode platform API response")
 	}
 
-	platforms = filterPlatform(platform, platforms)
+	platforms = filterPlatform(tagPath, platform, platforms)
 
 	switch len(platforms) {
 	case 0:
@@ -153,11 +156,11 @@ func playerStats(profilePath string, platform string) (*PlayerStats, error) {
 }
 
 // Filters the platform slice to return only matching platforms
-func filterPlatform(platform string, platforms []Platform) []Platform {
+func filterPlatform(tagPath, platform string, platforms []Platform) []Platform {
 	out := make([]Platform, 0)
 
 	for _, p := range platforms {
-		if p.Platform == platform {
+		if p.Platform == platform && (platform != PlatformNS || p.URLName == tagPath) {
 			out = append(out, p)
 		}
 	}

--- a/ovrstat/player_stats.go
+++ b/ovrstat/player_stats.go
@@ -95,7 +95,7 @@ func playerStats(profilePath string, platform string) (*PlayerStats, error) {
 	apiPath := tagPath
 
 	if platform == PlatformNS {
-		apiPath = apiPath[0:strings.Index(apiPath, "-")] + "/"
+		apiPath = apiPath[0:strings.Index(apiPath, "-")]
 	} else if platform != PlatformPSN {
 		apiPath = strings.Replace(apiPath, "-", "%23", -1)
 	}


### PR DESCRIPTION
This patch may resolve the issues with Nintendo Switch profiles, specifically where the API endpoint doesn't support Switch queries with the uuid. This will match the uuid to the `urlName` attribute if possible.

Somewhat messy, and may not be perfect - would appreciate others testing this patch as well.