### PR TITLE
Add (competitive) season

### DIFF
--- a/ovrstat/models.go
+++ b/ovrstat/models.go
@@ -2,20 +2,19 @@ package ovrstat
 
 // PlayerStats holds all stats on a specified Overwatch player
 type PlayerStats struct {
-	Icon              string          `json:"icon"`
-	Name              string          `json:"name"`
-	Level             int             `json:"level"`
-	LevelIcon         string          `json:"levelIcon"`
-	Endorsement       int             `json:"endorsement"`
-	EndorsementIcon   string          `json:"endorsementIcon"`
-	Prestige          int             `json:"prestige"`
-	PrestigeIcon      string          `json:"prestigeIcon"`
-	CompetitiveSeason *int            `json:"competitiveSeason"`
-	Ratings           []Rating        `json:"ratings"`
-	GamesWon          int             `json:"gamesWon"`
-	QuickPlayStats    StatsCollection `json:"quickPlayStats"`
-	CompetitiveStats  StatsCollection `json:"competitiveStats"`
-	Private           bool            `json:"private"`
+	Icon             string                     `json:"icon"`
+	Name             string                     `json:"name"`
+	Level            int                        `json:"level"`
+	LevelIcon        string                     `json:"levelIcon"`
+	Endorsement      int                        `json:"endorsement"`
+	EndorsementIcon  string                     `json:"endorsementIcon"`
+	Prestige         int                        `json:"prestige"`
+	PrestigeIcon     string                     `json:"prestigeIcon"`
+	Ratings          []Rating                   `json:"ratings"`
+	GamesWon         int                        `json:"gamesWon"`
+	QuickPlayStats   QuickPlayStatsCollection   `json:"quickPlayStats"`
+	CompetitiveStats CompetitiveStatsCollection `json:"competitiveStats"`
+	Private          bool                       `json:"private"`
 }
 
 type Rating struct {
@@ -25,10 +24,18 @@ type Rating struct {
 	RankIcon string `json:"rankIcon"`
 }
 
-// StatsCollection holds a collection of stats for a particular player
 type StatsCollection struct {
 	TopHeroes   map[string]*TopHeroStats `json:"topHeroes"`
 	CareerStats map[string]*CareerStats  `json:"CareerStats"`
+}
+
+type CompetitiveStatsCollection struct {
+	Season *int `json:"season"`
+	StatsCollection
+}
+
+type QuickPlayStatsCollection struct {
+	StatsCollection
 }
 
 // TopHeroStats holds basic stats for each hero

--- a/ovrstat/models.go
+++ b/ovrstat/models.go
@@ -2,19 +2,20 @@ package ovrstat
 
 // PlayerStats holds all stats on a specified Overwatch player
 type PlayerStats struct {
-	Icon             string          `json:"icon"`
-	Name             string          `json:"name"`
-	Level            int             `json:"level"`
-	LevelIcon        string          `json:"levelIcon"`
-	Endorsement      int             `json:"endorsement"`
-	EndorsementIcon  string          `json:"endorsementIcon"`
-	Prestige         int             `json:"prestige"`
-	PrestigeIcon     string          `json:"prestigeIcon"`
-	Ratings          []Rating        `json:"ratings"`
-	GamesWon         int             `json:"gamesWon"`
-	QuickPlayStats   StatsCollection `json:"quickPlayStats"`
-	CompetitiveStats StatsCollection `json:"competitiveStats"`
-	Private          bool            `json:"private"`
+	Icon              string          `json:"icon"`
+	Name              string          `json:"name"`
+	Level             int             `json:"level"`
+	LevelIcon         string          `json:"levelIcon"`
+	Endorsement       int             `json:"endorsement"`
+	EndorsementIcon   string          `json:"endorsementIcon"`
+	Prestige          int             `json:"prestige"`
+	PrestigeIcon      string          `json:"prestigeIcon"`
+	CompetitiveSeason *int            `json:"competitiveSeason"`
+	Ratings           []Rating        `json:"ratings"`
+	GamesWon          int             `json:"gamesWon"`
+	QuickPlayStats    StatsCollection `json:"quickPlayStats"`
+	CompetitiveStats  StatsCollection `json:"competitiveStats"`
+	Private           bool            `json:"private"`
 }
 
 type Rating struct {

--- a/ovrstat/player_stats.go
+++ b/ovrstat/player_stats.go
@@ -89,14 +89,6 @@ func playerStats(profilePath string, platform string) (*PlayerStats, error) {
 	// Scrapes all stats for the passed user and sets struct member data
 	ps := parseGeneralInfo(pd.Find("div.masthead").First())
 
-	competitiveSeason, _ := pd.Find("div[data-competitive-season]").Attr("data-competitive-season")
-
-	if competitiveSeason != "" {
-		competitiveSeason, _ := strconv.Atoi(competitiveSeason)
-
-		ps.CompetitiveSeason = &competitiveSeason
-	}
-
 	// Perform api request
 	var platforms []Platform
 
@@ -158,8 +150,23 @@ func playerStats(profilePath string, platform string) (*PlayerStats, error) {
 		return &ps, nil
 	}
 
-	ps.QuickPlayStats = parseDetailedStats(pd.Find("div#quickplay").First())
-	ps.CompetitiveStats = parseDetailedStats(pd.Find("div#competitive").First())
+	quickPlayStats := parseDetailedStats(pd.Find("div#quickplay").First())
+
+	ps.QuickPlayStats.CareerStats = quickPlayStats.CareerStats
+	ps.QuickPlayStats.TopHeroes = quickPlayStats.TopHeroes
+
+	competitiveStats := parseDetailedStats(pd.Find("div#competitive").First())
+
+	ps.CompetitiveStats.CareerStats = competitiveStats.CareerStats
+	ps.CompetitiveStats.TopHeroes = competitiveStats.TopHeroes
+
+	competitiveSeason, _ := pd.Find("div[data-competitive-season]").Attr("data-competitive-season")
+
+	if competitiveSeason != "" {
+		competitiveSeason, _ := strconv.Atoi(competitiveSeason)
+
+		ps.CompetitiveStats.Season = &competitiveSeason
+	}
 
 	return &ps, nil
 }

--- a/ovrstat/player_stats.go
+++ b/ovrstat/player_stats.go
@@ -89,6 +89,14 @@ func playerStats(profilePath string, platform string) (*PlayerStats, error) {
 	// Scrapes all stats for the passed user and sets struct member data
 	ps := parseGeneralInfo(pd.Find("div.masthead").First())
 
+	competitiveSeason, _ := pd.Find("div[data-competitive-season]").Attr("data-competitive-season")
+
+	if competitiveSeason != "" {
+		competitiveSeason, _ := strconv.Atoi(competitiveSeason)
+
+		ps.CompetitiveSeason = &competitiveSeason
+	}
+
 	// Perform api request
 	var platforms []Platform
 

--- a/ovrstat/player_stats.go
+++ b/ovrstat/player_stats.go
@@ -150,15 +150,8 @@ func playerStats(profilePath string, platform string) (*PlayerStats, error) {
 		return &ps, nil
 	}
 
-	quickPlayStats := parseDetailedStats(pd.Find("div#quickplay").First())
-
-	ps.QuickPlayStats.CareerStats = quickPlayStats.CareerStats
-	ps.QuickPlayStats.TopHeroes = quickPlayStats.TopHeroes
-
-	competitiveStats := parseDetailedStats(pd.Find("div#competitive").First())
-
-	ps.CompetitiveStats.CareerStats = competitiveStats.CareerStats
-	ps.CompetitiveStats.TopHeroes = competitiveStats.TopHeroes
+	parseDetailedStats(pd.Find("div#quickplay").First(), &ps.QuickPlayStats.StatsCollection)
+	parseDetailedStats(pd.Find("div#competitive").First(), &ps.CompetitiveStats.StatsCollection)
 
 	competitiveSeason, _ := pd.Find("div[data-competitive-season]").Attr("data-competitive-season")
 
@@ -239,11 +232,9 @@ func parseGeneralInfo(s *goquery.Selection) PlayerStats {
 }
 
 // parseDetailedStats populates the passed stats collection with detailed statistics
-func parseDetailedStats(playModeSelector *goquery.Selection) StatsCollection {
-	var sc StatsCollection
+func parseDetailedStats(playModeSelector *goquery.Selection, sc *StatsCollection) {
 	sc.TopHeroes = parseHeroStats(playModeSelector.Find("div.progress-category").Parent())
 	sc.CareerStats = parseCareerStats(playModeSelector.Find("div.js-stats").Parent())
-	return sc
 }
 
 // parseHeroStats : Parses stats for each individual hero and returns a map


### PR DESCRIPTION
Adds `season` to `competitiveStats` (with typing `int|null`) to provide information of which season the stats are from.